### PR TITLE
add path normalization

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ export function activate (context: vscode.ExtensionContext) {
   function addTests (parent: vscode.TestItem, uri: vscode.Uri, filePath: String, baseName: String, definitions: Test[]) {
     definitions.forEach((definition) => {
       const name = `${baseName}${baseName.length > 0 ? ' ' : ''}${definition.name}`
-      const id = `${normalizePath(filePath)}:${name}`
+      const id = `${normalizePath(filePath as string)}:${name}`
       const test = controller.createTestItem(id, definition.name, uri)
       test.range = new vscode.Range(
         new vscode.Position(definition.loc.start.line - 1, definition.loc.start.column),


### PR DESCRIPTION
This is fix for https://github.com/BuBuaBu/vscode-busted-test-explorer/issues/1
I'm not an expert in TS but this kind of normalization works fine on Windows. Unfortunately, I am unable to check this solution on other platforms.