### PR TITLE
Fix reporter.lua:17: attempt to index local 'element' (a nil value)

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -40,7 +40,7 @@ export async function execute (
 
   await new Promise((resolve: Function, reject: Function) => {
     const args = [
-      ...[...filter].map(name => `--filter=${name}`),
+      ...[...filter].map(name => `--filter=${name.replace(/ /gi, "%s")}$`),
       '-o', reporterPath,
       ...config.getArguments(),
       ...files


### PR DESCRIPTION
The problem occurred when the test name contained spaces (e.g.: --filter=Action Group should....), the value was split by the spaces and so busted only took "--filter=Action" and not the rest, which was taken as the path for the ROOT test file.
This led to errors when trying to launch "should", for example.
Replace spaces by %s lua pattern and add $ pattern lua for end of string